### PR TITLE
Configure and report DB logger initialization

### DIFF
--- a/back-end/Config.yaml
+++ b/back-end/Config.yaml
@@ -3,6 +3,7 @@ DatabaseUsername: bgUser
 DatabasePassword: 123456
 DatabaseHost: 10.1.18.5
 DatabaseName: bgdb
+DatabaseLogCommitBatchSize: 64 # Count of DB log operations to batch before committing
 
 # Set Socket Params Here #
 SocketBindAddress: 0.0.0.0 # Bind To All Addresses By Default
@@ -72,4 +73,3 @@ ZKPort: 2181
 
 APIServerAddress: 0.0.0.0 # Set the IP Address Used By The HTTPS Side Of The API Server
 APIServerPort: 2002 # Set The Port Used By The HTTPS Side Of The API Server
-

--- a/back-end/Core/Management/Logger/DBLoggerThread.py
+++ b/back-end/Core/Management/Logger/DBLoggerThread.py
@@ -22,24 +22,28 @@ class DatabaseLogTransmissionSystem(): # Transmits Logs From The Logger To The D
         self.Logger.Log('Initializing Database Log Transmission System', 4)
         self.OpsBeforeCommit = self.ConfigureOpsBeforeCommit(SystemConfiguration) # Count of DB operations to be executed before committing #
 
-        # TODO: Wrap further initialization in try/except; log errors in case there are any
-        # Connect To DB #
-        DBUsername = str(SystemConfiguration.get('DatabaseUsername'))
-        DBPassword = str(SystemConfiguration.get('DatabasePassword'))
-        DBHost = str(SystemConfiguration.get('DatabaseHost'))
-        DBDatabaseName = str(SystemConfiguration.get('DatabaseName'))
+        try:
+            # Connect To DB #
+            DBUsername = str(SystemConfiguration.get('DatabaseUsername'))
+            DBPassword = str(SystemConfiguration.get('DatabasePassword'))
+            DBHost = str(SystemConfiguration.get('DatabaseHost'))
+            DBDatabaseName = str(SystemConfiguration.get('DatabaseName'))
 
-        # Connect To Database #
-        self.DatabaseConnection = pymysql.connect(
-            host = DBHost,
-            user = DBUsername,
-            password = DBPassword,
-            db = DBDatabaseName
-        )
+            # Connect To Database #
+            self.DatabaseConnection = pymysql.connect(
+                host = DBHost,
+                user = DBUsername,
+                password = DBPassword,
+                db = DBDatabaseName
+            )
 
-        # Create Database Cursor #
-        self.LoggerCursor = self.DatabaseConnection.cursor()
-        # TODO: (maybe) log successful initialization
+            # Create Database Cursor #
+            self.LoggerCursor = self.DatabaseConnection.cursor()
+        except Exception as Error:
+            self.Logger.Log('Failed to initialize Database Log Transmission System: ' + str(Error), 10)
+            raise
+
+        self.Logger.Log('Database Log Transmission System Initialized Successfully', 4)
 
 
     def ConfigureOpsBeforeCommit(self, SystemConfiguration:dict): # Load DB commit batch size from config #

--- a/back-end/Core/Management/Logger/DBLoggerThread.py
+++ b/back-end/Core/Management/Logger/DBLoggerThread.py
@@ -15,14 +15,12 @@ class DatabaseLogTransmissionSystem(): # Transmits Logs From The Logger To The D
 
     def __init__(self, Logger:object, LogBufferQueue:object, ControlQueue:object, SystemConfiguration:dict): # Init #
 
-        # TODO: Make this part of parameters
-        self.OpsBeforeCommit = 64 # Count of DB operations to be executed before committing #
-
         # Init Logger #
         self.Logger = Logger
         self.LogBufferQueue = LogBufferQueue
         self.ControlQueue = ControlQueue
         self.Logger.Log('Initializing Database Log Transmission System', 4)
+        self.OpsBeforeCommit = self.ConfigureOpsBeforeCommit(SystemConfiguration) # Count of DB operations to be executed before committing #
 
         # TODO: Wrap further initialization in try/except; log errors in case there are any
         # Connect To DB #
@@ -42,6 +40,24 @@ class DatabaseLogTransmissionSystem(): # Transmits Logs From The Logger To The D
         # Create Database Cursor #
         self.LoggerCursor = self.DatabaseConnection.cursor()
         # TODO: (maybe) log successful initialization
+
+
+    def ConfigureOpsBeforeCommit(self, SystemConfiguration:dict): # Load DB commit batch size from config #
+
+        DefaultOpsBeforeCommit = 64
+        ConfiguredOpsBeforeCommit = SystemConfiguration.get('DatabaseLogCommitBatchSize', DefaultOpsBeforeCommit)
+
+        try:
+            OpsBeforeCommit = int(ConfiguredOpsBeforeCommit)
+        except (TypeError, ValueError):
+            self.Logger.Log('Invalid DatabaseLogCommitBatchSize; using default value of ' + str(DefaultOpsBeforeCommit), 8)
+            return DefaultOpsBeforeCommit
+
+        if OpsBeforeCommit < 1:
+            self.Logger.Log('DatabaseLogCommitBatchSize must be at least 1; using 1', 8)
+            return 1
+
+        return OpsBeforeCommit
 
 
     def ShouldStop(self): # Check If Thread Should Exit #


### PR DESCRIPTION
## Summary
- add `DatabaseLogCommitBatchSize` to `Config.yaml` with the existing default of 64 operations
- load the DB logger commit batch size from configuration
- validate invalid values back to 64 and clamp nonpositive values to 1
- log successful DB logger initialization and log/re-raise database setup failures

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `python3 -m py_compile back-end/Core/Management/Logger/DBLoggerThread.py`
- focused Python probe for default, configured, invalid, and nonpositive `DatabaseLogCommitBatchSize` values plus DB setup success/failure logging
- `git diff --check`
- clean full-branch patch apply to a temporary `origin/master` worktree
