### PR TITLE
Reject invalid UI login credentials

### DIFF
--- a/back-end/Core/BackendAPIClient/SocketClient.py
+++ b/back-end/Core/BackendAPIClient/SocketClient.py
@@ -179,22 +179,29 @@ class SocketClient(): # Creates A Client Socket System #
                 db = DBDatabaseName
         )
 
-        cur = self.DatabaseConnection.cursor(pymysql.cursors.DictCursor)
+        try:
+            cur = self.DatabaseConnection.cursor(pymysql.cursors.DictCursor)
 
-        cur.execute("SELECT * FROM user WHERE userName=%s AND passwordHash=%s",(userName,passwordHash))
-        userCursor = cur
+            matchedUserCount = cur.execute(
+                "SELECT * FROM user WHERE userName=%s AND passwordHash=%s",
+                (userName,passwordHash)
+            )
+            if matchedUserCount == 0:
+                return False
 
-        for row in userCursor:
-            level = row['permissionLevel']
-            cur.execute("SELECT * FROM command WHERE permissionLevel=%s",level)
+            userRows = list(cur)
+            for row in userRows:
+                level = row['permissionLevel']
+                cur.execute("SELECT * FROM command WHERE permissionLevel=%s",(level,))
 
-            print("Executable Commands for current permission level:")
-            for row1 in cur:
-                print(row1['commandName'],"\t",row1['commandDescription'])
+                print("Executable Commands for current permission level:")
+                for row1 in cur:
+                    print(row1['commandName'],"\t",row1['commandDescription'])
 
-        self.DatabaseConnection.close()
-        
-        return True
+            return True
+
+        finally:
+            self.DatabaseConnection.close()
 
     def addUser(self, userName:str, passwordHash:str, salt:str, firstName:str, lastName:str, notes:str, permissionLevel:int):
 


### PR DESCRIPTION
Summary:
- return false from WriteAuthentication when the credential query matches no users
- close the DB connection through a finally block on both valid and invalid login paths
- keep the existing command-permission listing for matched users

Verification:
- python3 -m py_compile back-end/Core/BackendAPIClient/SocketClient.py
- focused fake-DB probe for zero-row invalid credentials and one-row valid credentials
- git diff --check
- clean patch apply against origin/master

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.