### PR TITLE
Format API server exception messages safely

### DIFF
--- a/back-end/APIServer.py
+++ b/back-end/APIServer.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
         )
 
     except Exception as e:
-        print('Error: Key and Certificate could not be loaded' + e)
+        print(f'Error: Key and Certificate could not be loaded: {e}')
 
     # Shutdown Server #
     os._exit(0)
@@ -155,7 +155,7 @@ async def root(RequestJSON: Request):
             return {'Name':'Error', 'Content':'ScopeError: No Valid Server Is Available To Handle Your Request With The Given Scope. Valid Scopes Are "NES", "ERS", "STS".'}
 
     except Exception as e:
-        print('Error: ' + e)
+        print(f'Error: {e}')
 
 # Add a new user #
 @API.post('/AddUser')


### PR DESCRIPTION
Summary:
- format API server startup and request-handler exceptions with f-strings
- avoid raising a secondary TypeError while reporting the original exception

Verification:
- python3 -m py_compile back-end/APIServer.py
- grep check confirming no remaining string-plus-exception pattern in APIServer.py
- git diff --check
- clean patch apply against origin/master

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.