### PR TITLE
Honor non-expiring auth tokens

### DIFF
--- a/back-end/Core/BackendAPIClient/Auth.py
+++ b/back-end/Core/BackendAPIClient/Auth.py
@@ -45,9 +45,10 @@ class AuthenticationManager(): # Handles Auth for API #
         try:
             # AssociatedUsername = self.Tokens[Token]['Username']
             TokenExpireDate = self.Tokens[Token]['ExpireTime']
+            TokenExpires = self.Tokens[Token].get('TokenExpires', True)
 
             # Check If Token Expired #
-            if time.time() > TokenExpireDate:
+            if TokenExpires and time.time() > TokenExpireDate:
                 Response = 'Expired Token'
 
             # Valid Token #


### PR DESCRIPTION
Summary:
- make ValidateToken honor the stored TokenExpires flag
- preserve legacy behavior for tokens without the flag by treating them as expiring

Verification:
- python3 -m py_compile back-end/Core/BackendAPIClient/Auth.py
- focused auth-token expiry probe for valid, expired, non-expiring, legacy, and missing tokens
- git diff --check
- clean patch apply against origin/master

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.