### PR TITLE
Fix partition telemetry getters

### DIFF
--- a/back-end/Core/Management/Telemetry/TelemetryAPI.py
+++ b/back-end/Core/Management/Telemetry/TelemetryAPI.py
@@ -282,7 +282,7 @@ class TelemetryAPI(): # Exposes Telemetry Functions To The Leader #
 
         # Get The Info #
         NodeJSON = self.LeaderAttributes.Info[NodeName]
-        Info = NodeJSON['PartitonFree']
+        Info = NodeJSON['PartitionFree']
 
         # Return The Information #
         return Info

--- a/back-end/Core/Management/Telemetry/TelemetryAPI.py
+++ b/back-end/Core/Management/Telemetry/TelemetryAPI.py
@@ -248,7 +248,7 @@ class TelemetryAPI(): # Exposes Telemetry Functions To The Leader #
         return Info
 
 
-    def GetPartitonFileSystemType(self, NodeName): # Gets Node Info #
+    def GetPartitionFileSystemType(self, NodeName): # Gets Node Info #
 
         # Get The Info #
         NodeJSON = self.LeaderAttributes.Info[NodeName]
@@ -256,6 +256,11 @@ class TelemetryAPI(): # Exposes Telemetry Functions To The Leader #
 
         # Return The Information #
         return Info
+
+    def GetPartitonFileSystemType(self, NodeName): # Gets Node Info #
+
+        # Preserve the old misspelled API name for existing callers.
+        return self.GetPartitionFileSystemType(NodeName)
 
 
     def GetPartitionTotalBytes(self, NodeName): # Gets Node Info #


### PR DESCRIPTION
Summary
- Read the telemetry partition free-space list from the producer key `PartitionFree`.
- Add the correctly spelled `GetPartitionFileSystemType()` getter while preserving the old misspelled `GetPartitonFileSystemType()` name as a compatibility wrapper.
- Preserve the file with a final newline.

Verification
- python3 -m py_compile back-end/Core/Management/Telemetry/TelemetryAPI.py
- Focused import probe for `TelemetryAPI.GetPartitionFreeBytes()` returning `[123]` from `PartitionFree`.
- Focused import probe for `GetPartitionFileSystemType()` and legacy `GetPartitonFileSystemType()` returning `["apfs"]` from `PartitionFileSystemType`.
- git diff --check
- Clean full-branch patch apply against origin/master

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.
