### PR TITLE
Fix management API authentication flow

### DIFF
--- a/back-end/Core/Management/API/ManagementAPI.py
+++ b/back-end/Core/Management/API/ManagementAPI.py
@@ -406,7 +406,7 @@ class ManagementAPISocketServer(): # Creates A Class To Connect To The Managemen
                     self.UpdateCommand()
 
     #Returns list of commands that a user can execute based on his/her permission level
-    def WriteAuthentication(self):
+    def WriteAuthentication(self, userName:str, passwordHash:str):
 
         # Get Database Config #
         SystemConfiguration = self.SystemConfiguration
@@ -427,33 +427,28 @@ class ManagementAPISocketServer(): # Creates A Class To Connect To The Managemen
 
         cur = self.DatabaseConnection.cursor(pymysql.cursors.DictCursor)
 
-        rows = cur.execute("SELECT * FROM user WHERE userName=%s AND passwordHash=%s",(DBUsername,DBPassword))
-        
-        if rows==0:
-            else:
-            print("No matching user found in Database.")
-            salt = input("Enter salt")                                                                                                                                                                   
-            firstName = input("Enter first name")                                                                                                                                                        
-            lastName = input("Enter last name")
-            notes = input("Enter notes")                                                                                                                                                                 
-            permissionLevel = 1
-            addUser(userName,passwordHash,salt,firstName,lastName,notes,permissionLevel)
-            cur = self.DatabaseConnection.cursor(pymysql.cursors.DictCursor)                                                                                                             
-            rows= cur.execute("SELECT permissionLevel FROM user WHERE userName=%s AND passwordHash=%s",(userName,passwordHash))                                                                                
+        rows = cur.execute("SELECT * FROM user WHERE userName=%s AND passwordHash=%s",(userName,passwordHash))
+        userCursor = cur
 
-        for row in rows:
+        if rows==0:
+            print("No matching user found in Database.")
+            self.DatabaseConnection.close()
+            return False
+
+        for row in userCursor:
             level = row['permissionLevel']
-            rows = cur.execute("SELECT * FROM command WHERE permissionLevel=%d",int(level))
+            rows = cur.execute("SELECT * FROM command WHERE permissionLevel=%s",int(level))
 
             if rows!=0:
                 print("Executable Commands for current permission level:")
-                for row in rows:
-                    print(row['commandName'],"\t",row['commandDescription'])
+                for commandRow in cur:
+                    print(commandRow['commandName'],"\t",commandRow['commandDescription'])
 
             else:
                 print("No commands available for current permission level")
 
         self.DatabaseConnection.close()
+        return True
 
     def addUser(self, SystemConfiguration:dict, userName:str, passwordHash:str, salt:str, firstName:str, lastName:str, notes:str, permissionLevel:int):
 


### PR DESCRIPTION
## Summary
- fix the syntax error in `ManagementAPISocketServer.WriteAuthentication()`
- make the method accept the username/password hash it authenticates instead of checking database credentials
- return `False` for missing users and iterate DB cursors correctly when listing permitted commands

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `python3 -m py_compile back-end/Core/Management/API/ManagementAPI.py`
- focused import-stub probe for no-match and matching-user authentication paths
- explicit open-PR file overlap check for `back-end/Core/Management/API/ManagementAPI.py`
- `git diff --check`
- clean patch apply against a fresh `origin/master` checkout with `git apply --check --whitespace=error-all`
