### PR TITLE
Fix database prohibited character check

### DIFF
--- a/back-end/Core/Internode/Database/DatabaseInterface.py
+++ b/back-end/Core/Internode/Database/DatabaseInterface.py
@@ -101,7 +101,7 @@ class DBInterface(): # Interface to MySQL database #
     def CheckIfStringClean(self, String): # Checks If A String Is Clean (SQL INJECTION DETECTION) #
 
         # Perform The Check Against The Prohibited Strings List #
-        for Character in self.Prohibited:
+        for Character in self.ProhibitedChars:
             if Character in String:
                 self.Logger.Log(f'Potential MYSQL Injection Attack Detected: "{String}"', 4)
 


### PR DESCRIPTION
Summary:
- use the existing ProhibitedChars list in DBInterface.CheckIfStringClean()
- prevent CheckIfStringClean() from raising AttributeError before database user lookups

Verification:
- python3 -m py_compile back-end/Core/Internode/Database/DatabaseInterface.py
- focused stub probe for safe and prohibited strings without a database connection
- source probe confirming the missing self.Prohibited attribute is no longer referenced
- git diff --check
- clean patch apply against origin/master

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.