### PR TITLE
Guard empty dashboard averages

### DIFF
--- a/front-end/js/scripts.js
+++ b/front-end/js/scripts.js
@@ -129,6 +129,9 @@ let currentFetch = {};
 let fetchInt;
 let fetchRate = 1000;
 const totalAv = function(arr) {
+    if (!arr.length) {
+        return '0.00';
+    }
     let total = 0;
     arr.forEach(item => {
         total += item;


### PR DESCRIPTION
I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- Return `0.00` from the dashboard average helper when telemetry arrays are empty
- Prevent empty or filtered telemetry responses from pushing `NaN` into CPU/RAM charts and stats

## Verification
- git diff --check
- focused Node check for `totalAv([])` and `totalAv([10, 20, 30])`
- clean patch apply against fresh origin/master