### PR TITLE
Fix module DB host port connect

### DIFF
--- a/back-end/Core/Internode/Database/ModuleInstanceManager.py
+++ b/back-end/Core/Internode/Database/ModuleInstanceManager.py
@@ -27,7 +27,12 @@ class DatabaseInstanceCreator: # Pymysql Instance Creation System #
         # Connect To DB #
         self.DBUsername = str(DatabaseConfig.get('DatabaseUsername'))
         self.DBPassword = str(DatabaseConfig.get('DatabasePassword'))
-        self.DBHost = str(DatabaseConfig.get('DatabaseHost'))
+        DBHost = str(DatabaseConfig.get('DatabaseHost'))
+        self.DBHost = DBHost.split(':')[0]
+        if len(DBHost.split(':')) == 2:
+            self.DBPort = int(DBHost.split(':')[1])
+        else:
+            self.DBPort = None
         self.DBDatabaseName = str(DatabaseConfig.get('DatabaseName'))
 
 
@@ -63,7 +68,15 @@ class DatabaseInstanceCreator: # Pymysql Instance Creation System #
 
                     # Create Pymysql Instance For Thread #
                     Threads.append(threading.Thread.getName (ExistingThread))
-                    ExistingThread.PymysqlInstance = pymysql.connect(host = self.DBHost, user = self.DBUsername, password = self.DBPassword, db = self.DBDatabaseName)
+                    ConnectArgs = {
+                        'host': self.DBHost,
+                        'user': self.DBUsername,
+                        'password': self.DBPassword,
+                        'db': self.DBDatabaseName
+                    }
+                    if self.DBPort is not None:
+                        ConnectArgs['port'] = self.DBPort
+                    ExistingThread.PymysqlInstance = pymysql.connect(**ConnectArgs)
 
                     # Log Instance Creation #
                     self.Logger.Log("Database Instance Created for thread " + threading.Thread.getName (ExistingThread), 3)


### PR DESCRIPTION
I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- Parse `DatabaseHost` into host and optional port for per-thread PyMySQL connections
- Pass the validated port separately when `DatabaseHost` uses `host:port`, while preserving host-only configs

## Verification
- python3 -m py_compile back-end/Core/Internode/Database/ModuleInstanceManager.py
- focused monkeypatch probe for host-only and `127.0.0.1:3307` per-thread connection arguments
- git diff --check
- clean patch apply against fresh origin/master