### PR TITLE
Fix zookeeper leader lock check

### DIFF
--- a/back-end/Core/Internode/Zookeeper/Zookeeper.py
+++ b/back-end/Core/Internode/Zookeeper/Zookeeper.py
@@ -258,7 +258,7 @@ class ZK(): # Create Interface Class #
                 # Check Leader #
                 if not LeaderExists:
                     self.LeaderTimeout()
-                if not self.ZookeeperConnection.exists('/BrainGenix/System/Leader'):
+                if self.ZookeeperConnection.exists('/BrainGenix/System/Leader'):
                     if (self.ZookeeperConnection.get('/BrainGenix/System/Leader')[0] != self.Name.encode() and (self.ZookeeperMode == 'Leader')):
                         self.Logger.Log('Node Lock File Overwritten, Degrading To Follower!', 1)
                         self.ZookeeperMode = 'Follower'


### PR DESCRIPTION
I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- Check that the leader znode exists before reading it during leader-lock validation
- Avoid calling `get()` on a missing leader path after `LeaderTimeout()` and allow overwritten leader locks to degrade this node to follower

## Verification
- python3 -m py_compile back-end/Core/Internode/Zookeeper/Zookeeper.py
- focused fake-Zookeeper probe for missing leader znode and overwritten leader znode cases
- git diff --check
- clean patch apply against fresh origin/master