### PR TITLE
Bound thread manager shutdown joins

### DIFF
--- a/back-end/Core/ThreadManager.py
+++ b/back-end/Core/ThreadManager.py
@@ -45,6 +45,7 @@ class ThreadManager(): # This Class Manages Threads #
 
         # Create Local Var #
         self.ThreadsDestroyed = False
+        self.ThreadJoinTimeoutSeconds = 5.0
 
         # Register Exit Function #
         atexit.register(self.ShutdownSystem)
@@ -244,12 +245,20 @@ class ThreadManager(): # This Class Manages Threads #
             # Merge Threads #
             self.Logger.Log('Joining Threads', 2)
             for ThreadIndex in range(len(self.Threads)):
+                Thread = self.Threads[ThreadIndex]
+                ThreadName = getattr(Thread, 'name', f'Thread {ThreadIndex + 1}')
 
                 # Log Join Init #
                 self.Logger.Log(f'Joining Thread {ThreadIndex + 1}/{len(self.Threads)}', 0)
 
                 # Join Thread #
-                self.Threads[ThreadIndex].join()
+                Thread.join(timeout=self.ThreadJoinTimeoutSeconds)
+                if Thread.is_alive():
+                    TimeoutMessage = (
+                        f'Thread {ThreadIndex + 1} ({ThreadName}) did not stop within '
+                        f'{self.ThreadJoinTimeoutSeconds} seconds')
+                    self.Logger.Log(TimeoutMessage, 3)
+                    continue
 
                 # Log Join Completion #
                 self.Logger.Log(f'Joined Thread {ThreadIndex + 1}', 0)


### PR DESCRIPTION
## Summary
- add a per-manager shutdown join timeout
- pass the timeout to each thread join during shutdown
- log threads that ignore the stop signal instead of blocking forever

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- python3 -m py_compile back-end/Core/ThreadManager.py
- focused fake-thread shutdown probe covering stop-signal queue writes, bounded join timeouts, clean join logging, stuck-thread timeout logging, and CleanExit
- git diff --check
- clean patch apply against origin/master