### PR TITLE
Fix LADS follower shutdown queue

### DIFF
--- a/back-end/Core/LFTM/LADSManager.py
+++ b/back-end/Core/LFTM/LADSManager.py
@@ -74,7 +74,7 @@ class LADSManager(): # Manages the system telemetry leader class #
         self.Logger.Log('Joining LADS Daemon Threads', 3)
 
         self.Logger.Log('Sending LADS Daemon Control Queue Shutdown Message', 2)
-        self.LADSDaemon.ControlQueueDataCollectionDaemon.put('Stawp!')
+        self.LADSDaemon.ControlQueue.put('Stawp!')
         self.Logger.Log('Sent Shutdown Message To LADS Control Queue', 1)
 
         self.Logger.Log('Joining LADS Daemon To Main Thread', 2)


### PR DESCRIPTION
## Summary
- send the LADS follower shutdown signal to the LogAutoDeletionSystem ControlQueue that the daemon actually exposes
- keep the existing join/destruction flow unchanged after the stop signal is queued

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- python3 -m py_compile back-end/Core/LFTM/LADSManager.py
- focused stub probe covering TransitionFollower queue shutdown, thread join, and daemon cleanup
- git diff --check
- clean patch apply against origin/master in a detached worktree