### PR TITLE
Handle nonnumeric diagnostic config values

### DIFF
--- a/back-end/Core/Diagnostics/KafkaDiagnostics.py
+++ b/back-end/Core/Diagnostics/KafkaDiagnostics.py
@@ -76,7 +76,12 @@ def CanAccessKafka(KafkaConfigDict:dict, Logger:dict): # Runs Some Diagnostics A
     # Check If Address Valid Numbers #
     Logger.Log('Checking If Address Has Valid Numbers In Octets', 1)
     for Octet in Octets:
-        if (int(Octet) > 255) or (int(Octet) < 0):
+        try:
+            OctetNumber = int(Octet)
+        except ValueError:
+            Logger.Log('Invalid Non-Numeric Kafka Host Address Octet! Check Configuration File.', 3)
+            return False
+        if (OctetNumber > 255) or (OctetNumber < 0):
             Logger.Log('Invalid Number In Kafka Host Address Octet! Check Configuration File.', 3)
             return False
     Logger.Log('Octets Valid, Advancing To Next Test', 1)
@@ -93,14 +98,19 @@ def CanAccessKafka(KafkaConfigDict:dict, Logger:dict): # Runs Some Diagnostics A
 
     # Check If Port In Allowed Range #
     Logger.Log('Checking If Port In Allowed Range (0-65535)', 1)
-    if not ((int(Port) > 0) and (int(Port) < 65536)):
+    try:
+        PortNumber = int(Port)
+    except ValueError:
+        Logger.Log('Invalid Non-Numeric Kafka Port! Check Configuration File.', 3)
+        return False
+    if not ((PortNumber > 0) and (PortNumber < 65536)):
         Logger.Log('Port Outside Allwed Range, Please Check Configuration File')
         return False
     Logger.Log('Port Within Valid Range, Advancing To Next Test')
 
     # Check If Host Has Port Open #
     Logger.Log('Checking If Remote Host Has Port Open')
-    if not IsPortOpen(Address, Port):
+    if not IsPortOpen(Address, PortNumber):
         Logger.Log(f'Address {Address} Does Not Have Port {Port} Open, Check Configuration Or Kafka Service!', 3)
         return False
     else:

--- a/back-end/Core/Diagnostics/ZKDiagnostics.py
+++ b/back-end/Core/Diagnostics/ZKDiagnostics.py
@@ -72,14 +72,24 @@ def CanAccessZookeeper(ZKConfigDict:dict, Logger:object): # Runs Some Diagnostic
     # Check If Address Valid Numbers #
     Logger.Log('Checking If Address Has Valid Numbers In Octets', 1)
     for Octet in Octets:
-        if (int(Octet) > 255) or (int(Octet) < 0):
+        try:
+            OctetNumber = int(Octet)
+        except ValueError:
+            Logger.Log('Invalid Non-Numeric Zookeeper Host Address Octet! Check Configuration File.', 3)
+            return False
+        if (OctetNumber > 255) or (OctetNumber < 0):
             Logger.Log('Invalid Number In Zookeeper Host Address Octet! Check Configuration File.', 3)
             return False
     Logger.Log('Octets Valid, Advancing To Next Test', 1)
 
     # Check If Port In Allowed Range #
     Logger.Log('Checking If Port In Allowed Range (0-65535)', 1)
-    if not ((int(Port) > 0) and (int(Port) < 65536)):
+    try:
+        PortNumber = int(Port)
+    except ValueError:
+        Logger.Log('Invalid Non-Numeric Zookeeper Port! Check Configuration File.', 3)
+        return False
+    if not ((PortNumber > 0) and (PortNumber < 65536)):
         Logger.Log('Port Outside Allwed Range, Please Check Configuration File')
         return False
     Logger.Log('Port Within Valid Range, Advancing To Next Test')
@@ -96,7 +106,7 @@ def CanAccessZookeeper(ZKConfigDict:dict, Logger:object): # Runs Some Diagnostic
 
     # Check If Host Has Port Open #
     Logger.Log('Checking If Remote Host Has Port Open')
-    if not IsPortOpen(Address, Port):
+    if not IsPortOpen(Address, PortNumber):
         Logger.Log(f'Address {Address} Does Not Have Port {Port} Open, Check Configuration Or Zookeeper Service!', 3)
         return False
     else:


### PR DESCRIPTION
## Summary
- catch nonnumeric IPv4 octets in Kafka and Zookeeper diagnostics and return False with a logged configuration error
- catch nonnumeric Kafka/Zookeeper ports before port-range checks can raise
- reuse the validated integer port for socket checks

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- python3 -m py_compile back-end/Core/Diagnostics/ZKDiagnostics.py back-end/Core/Diagnostics/KafkaDiagnostics.py
- focused import-stub runtime probe covering nonnumeric octets and ports for both diagnostics modules
- source probe confirming ValueError handling and validated PortNumber socket checks
- git diff --check
- clean patch apply against origin/master in a detached worktree