### PR TITLE
Read latest CLAS log rows first

### DIFF
--- a/back-end/Core/Management/Logger/CLAS.py
+++ b/back-end/Core/Management/Logger/CLAS.py
@@ -68,7 +68,7 @@ class CentralizedLoggerAggregationSystem(): # Define Class for CLAS #
         NumLines = APIArgs['Lines']
 
         # Get Log Text #
-        self.LoggerCursor.execute("SELECT * FROM log LIMIT %d" % int(NumLines))
+        self.LoggerCursor.execute("SELECT * FROM log ORDER BY LogDatetime DESC LIMIT %s", (int(NumLines),))
 
         LogEntries = self.LoggerCursor.fetchall()
         CommandOutput = []


### PR DESCRIPTION
## Summary
- order CLAS log reads by LogDatetime descending so ReadLog returns the newest entries deterministically
- pass the row limit as a PyMySQL query parameter instead of interpolating it into the SQL string

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Testing
- python3 -m py_compile back-end/Core/Management/Logger/CLAS.py
- focused fake-cursor probe confirming the ORDER BY LogDatetime DESC query, parameterized limit, and timestamp conversion
- git diff --check origin/master
- clean origin/master worktree patch apply with git apply --check --whitespace=error-all