### PR TITLE
Validate Authenticate request bodies

### DIFF
--- a/back-end/APIServer.py
+++ b/back-end/APIServer.py
@@ -199,13 +199,20 @@ async def Authentication(RequestJSON: Request):
 
         # Decode Incoming JSON #
         RequestBytes = await RequestJSON.body()
-        CommandScope = json.loads(RequestBytes.decode())
+        try:
+            CommandScope = json.loads(RequestBytes.decode())
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return {'Error' : 'Invalid Authentication Request'}
+        if not isinstance(CommandScope, dict):
+            return {'Error' : 'Invalid Authentication Request'}
 
         print(CommandScope)
 
         # Get Uname, Passwd #
-        Username = CommandScope['Username']
-        Password = CommandScope['Password']
+        Username = CommandScope.get('Username')
+        Password = CommandScope.get('Password')
+        if not isinstance(Username, str) or not isinstance(Password, str):
+            return {'Error' : 'Invalid Authentication Request'}
 
         # Check Uname, Passwd #
         if sNESSocketConnection.WriteAuthentication(Username,Password):


### PR DESCRIPTION
Summary
- Catch malformed JSON and invalid UTF-8 in /Authenticate requests.
- Reject non-object bodies and missing or non-string Username/Password fields before calling the auth backend.
- Return the route's existing dictionary error style for malformed auth requests instead of raising a 500.

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.\n\nVerification\n- python3 -m py_compile back-end/APIServer.py\n- Focused coroutine probe with fake request/auth objects covering malformed JSON, invalid UTF-8, non-object body, missing fields, non-string fields, failed auth, and successful auth.\n- git diff --check\n- Clean patch apply against fresh origin/master.