### PR TITLE
Validate database diagnostic numeric config

### DIFF
--- a/back-end/Core/Diagnostics/DatabaseDiagnostics.py
+++ b/back-end/Core/Diagnostics/DatabaseDiagnostics.py
@@ -75,7 +75,12 @@ def CanAccessDatabase(DatabaseConfig:dict, Logger): # Runs Some Diagnostics Abou
     # Check If Address Valid Numbers #
     Logger.Log('Checking If Address Has Valid Numbers In Octets', 1)
     for Octet in Octets:
-        if (int(Octet) > 255) or (int(Octet) < 0):
+        try:
+            OctetNumber = int(Octet)
+        except ValueError:
+            Logger.Log('Invalid Non-Numeric Database Host Address Octet! Check Configuration File.', 3)
+            return False
+        if (OctetNumber > 255) or (OctetNumber < 0):
             Logger.Log('Invalid Number In Database Host Address Octet! Check Configuration File.', 3)
             return False
     Logger.Log('Octets Valid, Advancing To Next Test', 1)
@@ -89,6 +94,14 @@ def CanAccessDatabase(DatabaseConfig:dict, Logger): # Runs Some Diagnostics Abou
         return False
     else:
         Logger.Log('System Reachable, Advancing To Next Test', 1)
+
+    # Check If Port Is Numeric #
+    if Port != None:
+        try:
+            int(Port)
+        except ValueError:
+            Logger.Log('Invalid Non-Numeric Database Port! Check Configuration File.', 3)
+            return False
 
     # Check If Port In Allowed Range #
     if Port != None:


### PR DESCRIPTION
Summary
- Catch nonnumeric IPv4 octets in DatabaseDiagnostics before converting octets with int().
- Prevalidate nonnumeric database ports before the existing port-range and port-open checks.
- Return False with diagnostic log messages instead of crashing on malformed config values.

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.\n\nVerification\n- python3 -m py_compile back-end/Core/Diagnostics/DatabaseDiagnostics.py\n- Focused import/monkeypatch probe covering 127.x.0.1, 127.0.0.1:abc, and valid 127.0.0.1:3306 paths.\n- git diff --check\n- Clean patch apply against fresh origin/master.\n- Three-way merge simulation after applying UI PR #28 completed without conflicts.