### PR TITLE
Resolve API server certificate paths locally

### DIFF
--- a/back-end/APIServer.py
+++ b/back-end/APIServer.py
@@ -41,8 +41,14 @@ SystemConfiguration = LoadLocalConfig(ConfigFilePath = 'Config.yaml')
 # Start Uvicorn #
 if __name__ == '__main__':
 
-    if os.path.exists("/home/BrainGenix-UI/back-end/.gitsecret/key.pem")==False and os.path.exists("/home/BrainGenix-UI/back-end/.gitsecret/cert.pem")==False:
-        subprocess.call(['sh', './install.sh'])
+    BackendDirectory = os.path.dirname(os.path.abspath(__file__))
+    SecretDirectory = os.path.join(BackendDirectory, '.gitsecret')
+    InstallScript = os.path.join(BackendDirectory, 'install.sh')
+    SSLKeyFile = os.path.join(SecretDirectory, 'key.pem')
+    SSLCertFile = os.path.join(SecretDirectory, 'cert.pem')
+
+    if not (os.path.exists(SSLKeyFile) and os.path.exists(SSLCertFile)):
+        subprocess.call(['sh', InstallScript], cwd=BackendDirectory)  # nosec B603 - fixed repo-local script path
     
     try: 
 
@@ -53,8 +59,8 @@ if __name__ == '__main__':
             host=SystemConfiguration['APIServerAddress'],
             port=SystemConfiguration['APIServerPort'],
             log_level="info",
-            ssl_keyfile=".gitsecret/key.pem",
-            ssl_certfile=".gitsecret/cert.pem"
+            ssl_keyfile=SSLKeyFile,
+            ssl_certfile=SSLCertFile
         )
 
     except Exception as e:


### PR DESCRIPTION
I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- resolve APIServer certificate/key paths from the backend directory instead of a hardcoded /home path
- run install.sh from the backend directory when either certificate file is missing
- pass absolute certificate paths to uvicorn

## Verification
- python3 -m py_compile back-end/APIServer.py
- git diff --check origin/master...HEAD
- source probe confirming local certificate paths and install cwd